### PR TITLE
feat: Add initial composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ jobs:
 | `build_args` | Docker build arguments (multiline) | No | - |
 | `ghcr` | Enable GitHub Container Registry | No | `true` |
 | `ghcr_image_name` | GHCR image name | No | `ghcr.io/{owner}/{image_name}` |
-| `publish_on_pr` | Publish images on pull requests | No | `false` |
+| `publish_on_pr` | Publish images on pull requests (SHA tags only) | No | `false` |
 | `google_ar` | Enable Google Artifact Registry | No | `false` |
 | `google_ar_image_name` | GAR image name | No | - |
 | `google_workload_identity_provider` | Google Workload Identity Provider | No | - |
@@ -97,9 +97,9 @@ jobs:
 
 ### GitHub Container Registry (GHCR)
 
-- **Any push**: Creates SHA-tagged image
-- **Push to default branch**: Creates SHA-tagged + nightly
+- **Push to default branch**: Creates SHA-tagged + nightly images
 - **Pull requests**: Creates SHA-tagged image (if `publish_on_pr: 'true'`)
+- **All other pushes**: No publishing (build-only)
 
 ### Google Artifact Registry (GAR)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ This is a composite GitHub action that builds and publishes images to
 
 ## Usage
 
+**Required Permissions**
+Add the following permissions block to your workflow to allow publishing to GHCR and/or GAR:
+```yaml
+permissions:
+  contents: read
+  packages: write      # Required for GHCR
+  id-token: write      # Required for Google Artifact Registry (GAR)
+```
+If you're just building, `packages` should be set to `read` and `id-token` should be omitted.`
+```yaml
+permissions:
+  contents: read
+  packages: read      # Required to read from GHCR if using as cache
+  # id-token is omitted here
+```
+> Adjust permissions as needed for your use case. See [GitHub Actions permissions docs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) for more details.
+
 ### Basic Usage
 
 ```yaml
@@ -14,7 +31,7 @@ This is a composite GitHub action that builds and publishes images to
   uses: getsentry/action-build-and-push-images@sha
   with:
     image_name: 'sentry'
-    architecture: 'amd64'
+    platform: 'amd64'
 ```
 
 ### Multi-Architecture with Matrix Strategy
@@ -25,9 +42,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - architecture: amd64
+          - platform: amd64
             runner: ubuntu-latest
-          - architecture: arm64
+          - platform: arm64
             runner: ubuntu-latest-arm64
     runs-on: ${{ matrix.runner }}
     steps:
@@ -35,7 +52,7 @@ jobs:
         uses: getsentry/action-build-and-push-images@sha
         with:
           image_name: 'sentry'
-          architecture: ${{ matrix.architecture }}
+          platform: ${{ matrix.platform }}
 ```
 
 ### With Custom Build Configuration
@@ -45,7 +62,7 @@ jobs:
   uses: getsentry/action-build-and-push-images@sha
   with:
     image_name: 'sentry'
-    architecture: 'amd64'
+    platform: 'amd64'
     dockerfile_path: './docker/Dockerfile'
     build_context: './src'
     build_target: 'production'
@@ -61,7 +78,7 @@ jobs:
   uses: getsentry/action-build-and-push-images@sha
   with:
     image_name: 'sentry'
-    architecture: 'amd64'
+    platform: 'amd64'
 
     # Enable GAR publishing
     google_ar: 'true'
@@ -78,7 +95,7 @@ jobs:
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `image_name` | Base image name | Yes | - |
-| `architecture` | Architecture to build (amd64, arm64) | No | `amd64` |
+| `platform` | Platform to build (amd64, arm64) | No | `amd64` |
 | `dockerfile_path` | Path to Dockerfile | No | `./Dockerfile` |
 | `build_context` | Build context directory | No | `.` |
 | `build_target` | Docker build target stage | No | - |
@@ -90,8 +107,6 @@ jobs:
 | `google_ar_image_name` | GAR image name | No | - |
 | `google_workload_identity_provider` | Google Workload Identity Provider | No | - |
 | `google_service_account` | Google Service Account | No | - |
-| `cache_enabled` | Enable build cache | No | `true` |
-| `cache_suffix` | Cache image suffix | No | `cache` |
 
 ## Publishing Behavior
 
@@ -103,5 +118,5 @@ jobs:
 
 ### Google Artifact Registry (GAR)
 
-- **Push to default branch only**: Creates SHA-tagged + nightly
+- **Push to default branch only**: Creates SHA-tagged images (no nightly)
 - **All other events**: No publishing

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ jobs:
     # Enable GAR publishing
     google_ar: 'true'
     google_ar_image_name: 'us-central1-docker.pkg.dev/myproject/myrepo/myapp'
-    google_ar_tag_prefix: 'v'  # Optional: prefix for tags (e.g., v1.2.3)
 
     # Authentication (required for GAR)
     google_workload_identity_provider: 'projects/123/locations/global/workloadIdentityPools/pool/providers/provider'
@@ -89,7 +88,6 @@ jobs:
 | `publish_on_pr` | Publish images on pull requests | No | `false` |
 | `google_ar` | Enable Google Artifact Registry | No | `false` |
 | `google_ar_image_name` | GAR image name | No | - |
-| `google_ar_tag_prefix` | GAR tag prefix | No | - |
 | `google_workload_identity_provider` | Google Workload Identity Provider | No | - |
 | `google_service_account` | Google Service Account | No | - |
 | `cache_enabled` | Enable build cache | No | `true` |
@@ -100,10 +98,10 @@ jobs:
 ### GitHub Container Registry (GHCR)
 
 - **Any push**: Creates SHA-tagged image
-- **Push to main/master**: Creates SHA-tagged + latest images
+- **Push to default branch**: Creates SHA-tagged + nightly
 - **Pull requests**: Creates SHA-tagged image (if `publish_on_pr: 'true'`)
 
 ### Google Artifact Registry (GAR)
 
-- **Push to main/master only**: Creates SHA-tagged image
+- **Push to default branch only**: Creates SHA-tagged + nightly
 - **All other events**: No publishing

--- a/README.md
+++ b/README.md
@@ -1,1 +1,109 @@
+# action-build-and-push-images
 
+This is a composite GitHub action that builds and publishes images to
+
+- GitHub Container Registry (GHCR)
+- Google Artifact Registry (GAR)
+
+## Usage
+
+### Basic Usage
+
+```yaml
+- name: Build and push image
+  uses: getsentry/action-build-and-push-images@sha
+  with:
+    image_name: 'sentry'
+    architecture: 'amd64'
+```
+
+### Multi-Architecture with Matrix Strategy
+
+```yaml
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - architecture: amd64
+            runner: ubuntu-latest
+          - architecture: arm64
+            runner: ubuntu-latest-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Build and push image
+        uses: getsentry/action-build-and-push-images@sha
+        with:
+          image_name: 'sentry'
+          architecture: ${{ matrix.architecture }}
+```
+
+### With Custom Build Configuration
+
+```yaml
+- name: Build and push image
+  uses: getsentry/action-build-and-push-images@sha
+  with:
+    image_name: 'sentry'
+    architecture: 'amd64'
+    dockerfile_path: './docker/Dockerfile'
+    build_context: './src'
+    build_target: 'production'
+    build_args: |
+      ENVIRONMENT=production
+      DEBUG=false
+```
+
+### Publishing to Google Artifact Registry
+
+```yaml
+- name: Build and push image
+  uses: getsentry/action-build-and-push-images@sha
+  with:
+    image_name: 'sentry'
+    architecture: 'amd64'
+
+    # Enable GAR publishing
+    google_ar: 'true'
+    google_ar_image_name: 'us-central1-docker.pkg.dev/myproject/myrepo/myapp'
+    google_ar_tag_prefix: 'v'  # Optional: prefix for tags (e.g., v1.2.3)
+
+    # Authentication (required for GAR)
+    google_workload_identity_provider: 'projects/123/locations/global/workloadIdentityPools/pool/providers/provider'
+    google_service_account: 'service-account@project.iam.gserviceaccount.com'
+```
+
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `image_name` | Base image name | Yes | - |
+| `architecture` | Architecture to build (amd64, arm64) | No | `amd64` |
+| `dockerfile_path` | Path to Dockerfile | No | `./Dockerfile` |
+| `build_context` | Build context directory | No | `.` |
+| `build_target` | Docker build target stage | No | - |
+| `build_args` | Docker build arguments (multiline) | No | - |
+| `ghcr` | Enable GitHub Container Registry | No | `true` |
+| `ghcr_image_name` | GHCR image name | No | `ghcr.io/{owner}/{image_name}` |
+| `publish_on_pr` | Publish images on pull requests | No | `false` |
+| `google_ar` | Enable Google Artifact Registry | No | `false` |
+| `google_ar_image_name` | GAR image name | No | - |
+| `google_ar_tag_prefix` | GAR tag prefix | No | - |
+| `google_workload_identity_provider` | Google Workload Identity Provider | No | - |
+| `google_service_account` | Google Service Account | No | - |
+| `cache_enabled` | Enable build cache | No | `true` |
+| `cache_suffix` | Cache image suffix | No | `cache` |
+
+## Publishing Behavior
+
+### GitHub Container Registry (GHCR)
+
+- **Any push**: Creates SHA-tagged image
+- **Push to main/master**: Creates SHA-tagged + latest images
+- **Pull requests**: Creates SHA-tagged image (if `publish_on_pr: 'true'`)
+
+### Google Artifact Registry (GAR)
+
+- **Push to main/master only**: Creates SHA-tagged image
+- **All other events**: No publishing

--- a/action.yml
+++ b/action.yml
@@ -53,8 +53,13 @@ inputs:
     required: false
     default: ''
 
-  google_ar_tag_prefix:
-    description: 'Google Artifact Registry latest tag'
+  tag_prefix:
+    description: 'Tag prefix'
+    required: false
+    default: ''
+
+  tag_suffix:
+    description: 'Tag suffix'
     required: false
     default: ''
 
@@ -137,7 +142,7 @@ runs:
         images: ${{ steps.setup.outputs.ghcr_image_name }}
         tags: |
           # SHA for all events
-          type=sha,format=long
+          type=sha,format=long,prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }}
           # Nightly tags only for default branch pushes
           type=raw,value=nightly,enable={{is_default_branch}}
         labels: |
@@ -157,7 +162,7 @@ runs:
         images: ${{ inputs.google_ar_image_name }}
         tags: |
           # SHA for all events (no nightly for GAR)
-          type=sha,format=long
+          type=sha,format=long,prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }}
         labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}

--- a/action.yml
+++ b/action.yml
@@ -153,6 +153,39 @@ runs:
         echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
         echo "Using commit SHA: $COMMIT_SHA"
 
+    - name: Set up qemu
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
+      with:
+        platforms: ${{ inputs.platforms }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      with:
+        platforms: ${{ inputs.platforms }}
+
+
+    - name: Login to GHCR
+      if: steps.setup.outputs.publish_to_ghcr == 'true'
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+
+    - name: Setup Google Cloud authentication
+      if: steps.setup.outputs.publish_to_gar == 'true'
+      uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+      with:
+        workload_identity_provider: ${{ inputs.google_workload_identity_provider }}
+        service_account: ${{ inputs.google_service_account }}
+
+    - name: Configure Docker for Google Artifact Registry
+      if: steps.setup.outputs.publish_to_gar == 'true'
+      shell: bash
+      run: |
+        gcloud auth configure-docker $(echo "${{ inputs.google_ar_image_name }}" | cut -d'/' -f1)
+
     - name: Extract metadata for GHCR
       id: meta-ghcr
       if: steps.setup.outputs.publish_to_ghcr == 'true'
@@ -191,39 +224,6 @@ runs:
             org.opencontainers.image.version=${{ steps.setup.outputs.commit_sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
-
-    - name: Set up qemu
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
-      with:
-        platforms: ${{ inputs.platforms }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-      with:
-        platforms: ${{ inputs.platforms }}
-
-
-    - name: Login to GHCR
-      if: steps.setup.outputs.publish_to_ghcr == 'true'
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ github.token }}
-
-
-    - name: Setup Google Cloud authentication
-      if: steps.setup.outputs.publish_to_gar == 'true'
-      uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-      with:
-        workload_identity_provider: ${{ inputs.google_workload_identity_provider }}
-        service_account: ${{ inputs.google_service_account }}
-
-    - name: Configure Docker for Google Artifact Registry
-      if: steps.setup.outputs.publish_to_gar == 'true'
-      shell: bash
-      run: |
-        gcloud auth configure-docker $(echo "${{ inputs.google_ar_image_name }}" | cut -d'/' -f1)
 
     - name: Build and push
       id: build-and-push

--- a/action.yml
+++ b/action.yml
@@ -204,7 +204,6 @@ runs:
         tags: |
           ${{ steps.setup.outputs.publish_to_ghcr == 'true' && steps.meta-ghcr.outputs.tags || '' }}
           ${{ steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.tags || '' }}
-          ${{ steps.setup.outputs.will_publish == 'false' && format('build-{0}:{1}', inputs.image_name, github.pull_request.head.sha || github.sha) || '' }}
         labels: ${{ (steps.setup.outputs.publish_to_ghcr == 'true' && steps.meta-ghcr.outputs.labels) || (steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.labels) || '' }}
         annotations: ${{ (steps.setup.outputs.publish_to_ghcr == 'true' && steps.meta-ghcr.outputs.annotations) || (steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.annotations) || '' }}
         cache-from: type=gha,scope=${{ inputs.platform }}

--- a/action.yml
+++ b/action.yml
@@ -159,8 +159,8 @@ runs:
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.vendor="Sentry"
-            org.opencontainers.image.revision=${{ github.pull_request.head.sha || github.sha }}
-            org.opencontainers.image.version=${{ github.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.version=${{ github.event.pull_request.head.sha || github.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
 
@@ -177,8 +177,8 @@ runs:
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.vendor="Sentry"
-            org.opencontainers.image.revision=${{ github.pull_request.head.sha || github.sha }}
-            org.opencontainers.image.version=${{ github.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.version=${{ github.event.pull_request.head.sha || github.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,266 @@
+name: 'Build and Push Container Images'
+description: 'Builds images on PRs and builds/pushes to registries on main/release branches'
+
+inputs:
+  # Image configuration
+  image_name:
+    description: 'Base image name (e.g., myorg/myapp)'
+    required: true
+
+  dockerfile_path:
+    description: 'Path to Dockerfile'
+    required: false
+    default: './Dockerfile'
+
+  build_context:
+    description: 'Build context directory'
+    required: false
+    default: '.'
+
+  build_target:
+    description: 'Docker build target stage'
+    required: false
+    default: ''
+
+  build_args:
+    description: 'Docker build arguments (multiline)'
+    required: false
+    default: ''
+
+  # Registry configuration
+  ghcr:
+    description: 'Enable GitHub Container Registry'
+    required: false
+    default: 'true'
+
+  ghcr_image_name:
+    description: 'GHCR image name (defaults to ghcr.io/{owner}/{image_name})'
+    required: false
+    default: ''
+
+  publish_on_pr:
+    description: 'Publish images on pull requests (SHA tags only)'
+    required: false
+    default: 'false'
+
+  google_ar:
+    description: 'Enable Google Artifact Registry'
+    required: false
+    default: 'false'
+
+  google_ar_image_name:
+    description: 'Google Artifact Registry image name'
+    required: false
+    default: ''
+
+  google_ar_tag_prefix:
+    description: 'Google Artifact Registry latest tag'
+    required: false
+    default: ''
+
+  google_workload_identity_provider:
+    description: 'Google Workload Identity Provider'
+    required: false
+    default: ''
+
+  google_service_account:
+    description: 'Google Service Account'
+    required: false
+    default: ''
+
+  # Build configuration
+  architecture:
+    description: 'Architecture to build (e.g., amd64, arm64)'
+    required: false
+    default: 'amd64'
+
+  # Cache configuration
+  cache_enabled:
+    description: 'Enable build cache'
+    required: false
+    default: 'true'
+
+  cache_suffix:
+    description: 'Cache image suffix'
+    required: false
+    default: 'cache'
+
+outputs:
+  image:
+    description: 'Built image tag'
+    value: ${{ steps.output-images.outputs.image }}
+
+  image_digest:
+    description: 'Image digest'
+    value: ${{ steps.output-images.outputs.digest }}
+
+  pushed:
+    description: 'Whether image was pushed to registries'
+    value: ${{ steps.output-images.outputs.pushed }}
+
+runs:
+  using: 'composite'
+  steps:
+    # =============================================================================
+    # BUILD IMAGES
+    # =============================================================================
+
+    - name: Setup build metadata
+      id: setup
+      shell: bash
+      run: |
+        # Setup image names
+        GHCR_IMAGE_NAME="${{ inputs.ghcr_image_name }}"
+        if [[ -z "$GHCR_IMAGE_NAME" ]]; then
+          GHCR_IMAGE_NAME="ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}"
+        fi
+        echo "ghcr_image_name=$GHCR_IMAGE_NAME" >> $GITHUB_OUTPUT
+
+        # Use correct SHA for the event type
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
+        else
+          COMMIT_SHA="${{ github.sha }}"
+        fi
+        echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+        echo "Event: ${{ github.event_name }}"
+        echo "Branch: ${{ github.ref_name }}"
+        echo "Architecture: ${{ inputs.architecture }}"
+        echo "Commit SHA: $COMMIT_SHA"
+        if [[ "${{ inputs.google_ar }}" == "true" ]]; then
+          if [[ -z "${{ inputs.google_ar_image_name }}" ]]; then
+            echo "Error: Google Artifact Registry image name is required when publshing to Google Artifact Registry is enabled"
+            exit 1
+          fi
+          echo "GAR Image: ${{ inputs.google_ar_image_name }}"
+        fi
+        if [[ "${{ inputs.ghcr }}" == "true" ]]; then
+          echo "GHCR Image: $GHCR_IMAGE_NAME"
+        fi
+
+    - name: Build images for each architecture
+      id: build-images
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        ARCHITECTURE="${{ inputs.architecture }}"
+        GHCR_IMAGE_NAME="${{ steps.setup.outputs.ghcr_image_name }}"
+
+        echo "Building for architecture: $ARCHITECTURE"
+
+        # Set platform-specific runner (if needed)
+        PLATFORM="linux/$ARCHITECTURE"
+
+        # Define image tags
+        IMAGE="${GHCR_IMAGE_NAME}:${{ steps.setup.outputs.commit_sha }}"
+        CACHE_IMG="${GHCR_IMAGE_NAME}:${ARCHITECTURE}-${{ inputs.cache_suffix }}"
+
+        # Prepare build arguments
+        BUILD_ARGS=""
+        if [[ -n "${{ inputs.build_args }}" ]]; then
+          while IFS= read -r arg; do
+            if [[ -n "$arg" ]]; then
+              BUILD_ARGS="$BUILD_ARGS --build-arg $arg"
+            fi
+          done <<< "${{ inputs.build_args }}"
+        fi
+
+        # Prepare cache arguments
+        CACHE_ARGS=""
+        if [[ "${{ inputs.cache_enabled }}" == "true" ]]; then
+          if docker pull -q "$CACHE_IMG" 2>/dev/null; then
+            CACHE_ARGS="--cache-from $CACHE_IMG"
+          fi
+        fi
+
+        # Build target argument
+        TARGET_ARG=""
+        if [[ -n "${{ inputs.build_target }}" ]]; then
+          TARGET_ARG="--target ${{ inputs.build_target }}"
+        fi
+
+        # Build the image
+        docker buildx build \
+          --platform "$PLATFORM" \
+          --build-arg BUILDKIT_INLINE_CACHE=1 \
+          $BUILD_ARGS \
+          $CACHE_ARGS \
+          $TARGET_ARG \
+          --tag "$IMAGE" \
+          --tag "$CACHE_IMG" \
+          --file "${{ inputs.dockerfile_path }}" \
+          "${{ inputs.build_context }}"
+
+        # Output built image
+        echo "image=$IMAGE" >> $GITHUB_OUTPUT
+
+        echo "Built image: $IMAGE"
+
+    # =============================================================================
+    # PUBLISH TO GITHUB CONTAINER REGISTRY
+    # =============================================================================
+
+    - name: Login to GitHub Container Registry
+      if: inputs.ghcr == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && inputs.publish_on_pr == 'true'))
+      shell: bash
+      run: |
+        docker login ghcr.io -u "${{ github.actor }}" --password "${{ github.token }}"
+
+    - name: Push and tag image for GHCR
+      if: inputs.ghcr == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && inputs.publish_on_pr == 'true'))
+      shell: bash
+      run: |
+        GHCR_IMAGE_NAME="${{ steps.setup.outputs.ghcr_image_name }}"
+        IMAGE="${{ steps.build-images.outputs.image }}"
+
+        # Create and push SHA-tagged image
+        echo "Creating SHA-tagged image: ${GHCR_IMAGE_NAME}:${{ steps.setup.outputs.commit_sha }}"
+        docker tag "$IMAGE" "${GHCR_IMAGE_NAME}:${{ steps.setup.outputs.commit_sha }}"
+        docker push "${GHCR_IMAGE_NAME}:${{ steps.setup.outputs.commit_sha }}"
+
+        # Create and push latest tag only on main/master branches (not PRs)
+        if [[ "${{ github.event_name }}" == "push" && ("${{ github.ref_name }}" == "main" || "${{ github.ref_name }}" == "master") ]]; then
+          echo "Creating latest tag: ${GHCR_IMAGE_NAME}:latest"
+          docker tag "$IMAGE" "${GHCR_IMAGE_NAME}:latest"
+          docker push "${GHCR_IMAGE_NAME}:latest"
+        fi
+
+    # =============================================================================
+    # PUBLISH TO GOOGLE ARTIFACT REGISTRY
+    # =============================================================================
+
+    - name: Setup Google Cloud authentication
+      if: inputs.google_ar == 'true' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')
+      uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
+      with:
+        workload_identity_provider: ${{ inputs.google_workload_identity_provider }}
+        service_account: ${{ inputs.google_service_account }}
+
+    - name: Setup Google Cloud SDK
+      if: inputs.google_ar == 'true' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')
+      uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
+      with:
+        version: ">= 390.0.0"
+
+    - name: Configure Docker for Google Artifact Registry
+      if: inputs.google_ar == 'true' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')
+      shell: bash
+      run: |
+        if [[ -z "${{ inputs.google_ar_image_name }}" ]]; then
+          echo "Error: Google Artifact Registry image name is required when publshing to Google Artifact Registry is enabled"
+          exit 1
+        fi
+        gcloud auth configure-docker $(echo "${{ inputs.google_ar_image_name }}" | cut -d'/' -f1)
+
+    - name: Tag image for Google Artifact Registry
+      if: inputs.google_ar == 'true' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')
+      shell: bash
+      run: |
+        GAR_IMAGE_NAME="${{ inputs.google_ar_image_name }}"
+        IMAGE="${{ steps.build-images.outputs.image }}"
+
+        # Create and push SHA-tagged image
+        echo "Creating SHA-tagged image: ${GAR_IMAGE_NAME}:${{ inputs.google_ar_tag_prefix }}${{ steps.setup.outputs.commit_sha }}"
+        docker tag "$IMAGE" "${GAR_IMAGE_NAME}:${{ inputs.google_ar_tag_prefix }}${{ steps.setup.outputs.commit_sha }}"
+        docker push "${GAR_IMAGE_NAME}:${{ inputs.google_ar_tag_prefix }}${{ steps.setup.outputs.commit_sha }}"

--- a/action.yml
+++ b/action.yml
@@ -74,10 +74,10 @@ inputs:
     default: ''
 
   # Build configuration
-  platform:
-    description: 'platform to build (e.g., amd64, arm64)'
+  platforms:
+    description: 'platforms to build (e.g., linux/amd64, linux/arm64)'
     required: false
-    default: 'amd64'
+    default: 'linux/amd64'
 
 
 outputs:
@@ -105,7 +105,7 @@ runs:
 
         echo "Event: ${{ github.event_name }}"
         echo "Branch: ${{ github.ref_name }}"
-        echo "platform: ${{ inputs.platform }}"
+        echo "platforms: ${{ inputs.platforms }}"
         if [[ "${{ inputs.google_ar }}" == "true" ]]; then
           if [[ -z "${{ inputs.google_ar_image_name }}" ]]; then
             echo "Error: Google Artifact Registry image name is required when publishing to Google Artifact Registry is enabled"
@@ -185,6 +185,9 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
+    - name: Set up qemu
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
+
     - name: Login to GHCR
       if: steps.setup.outputs.publish_to_ghcr == 'true'
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
@@ -213,7 +216,7 @@ runs:
       with:
         context: ${{ inputs.build_context }}
         file: ${{ inputs.dockerfile_path }}
-        platforms: linux/${{ inputs.platform }}
+        platforms: ${{ inputs.platforms }}
         build-args: ${{ inputs.build_args }}
         target: ${{ inputs.build_target }}
         tags: |
@@ -221,8 +224,8 @@ runs:
           ${{ steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.tags || '' }}
         labels: ${{ (steps.setup.outputs.publish_to_ghcr == 'true' && steps.meta-ghcr.outputs.labels) || (steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.labels) || '' }}
         annotations: ${{ (steps.setup.outputs.publish_to_ghcr == 'true' && steps.meta-ghcr.outputs.annotations) || (steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.annotations) || '' }}
-        cache-from: type=gha,scope=${{ inputs.platform }}
-        cache-to: ${{ steps.setup.outputs.will_publish == 'true' && format('type=gha,mode=max,scope={0}', inputs.platform) || '' }}
+        cache-from: type=gha,scope=${{ inputs.platforms }}
+        cache-to: ${{ steps.setup.outputs.will_publish == 'true' && format('type=gha,mode=max,scope={0}', inputs.platforms) || '' }}
         provenance: ${{ steps.setup.outputs.will_publish == 'true' && 'mode=max' || 'false' }}
         sbom: ${{ steps.setup.outputs.will_publish == 'true' }}
         push: ${{ steps.setup.outputs.will_publish == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -167,11 +167,16 @@ runs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
 
-    - name: Login to GitHub Container Registry
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+    - name: Login to GHCR
       if: steps.setup.outputs.publish_to_ghcr == 'true'
-      shell: bash
-      run: |
-        docker login ghcr.io -u "${{ github.actor }}" --password "${{ github.token }}"
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
 
     - name: Setup Google Cloud authentication

--- a/action.yml
+++ b/action.yml
@@ -126,9 +126,29 @@ runs:
           echo "GHCR Image: $GHCR_IMAGE_NAME"
         fi
 
+        # Determine publishing conditions
+        PUBLISH_TO_GHCR="false"
+        PUBLISH_TO_GAR="false"
+
+        # GHCR: Publish on default branch push OR PR (if enabled)
+        if [[ "${{ inputs.ghcr }}" == "true" && (("${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}") || ("${{ github.event_name }}" == "pull_request" && "${{ inputs.publish_on_pr }}" == "true")) ]]; then
+          PUBLISH_TO_GHCR="true"
+        fi
+
+        # GAR: Publish on default branch push only
+        if [[ "${{ inputs.google_ar }}" == "true" && "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "${{ github.event.repository.default_branch }}" ]]; then
+          PUBLISH_TO_GAR="true"
+        fi
+
+        echo "publish_to_ghcr=$PUBLISH_TO_GHCR" >> $GITHUB_OUTPUT
+        echo "publish_to_gar=$PUBLISH_TO_GAR" >> $GITHUB_OUTPUT
+        echo "Publishing to GHCR: $PUBLISH_TO_GHCR"
+        echo "Publishing to GAR: $PUBLISH_TO_GAR"
+
+
     - name: Extract metadata for GHCR
       id: meta-ghcr
-      if: inputs.ghcr == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && inputs.publish_on_pr == 'true'))
+      if: steps.setup.outputs.publish_to_ghcr == 'true'
       uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
       with:
         images: ${{ steps.setup.outputs.ghcr_image_name }}
@@ -149,14 +169,14 @@ runs:
             org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
 
     - name: Login to GitHub Container Registry
-      if: inputs.ghcr == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && inputs.publish_on_pr == 'true'))
+      if: steps.setup.outputs.publish_to_ghcr == 'true'
       shell: bash
       run: |
         docker login ghcr.io -u "${{ github.actor }}" --password "${{ github.token }}"
 
     - name: Build and push to GHCR
       id: build-and-push-to-ghcr
-      if: inputs.ghcr == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && inputs.publish_on_pr == 'true'))
+      if: steps.setup.outputs.publish_to_ghcr == 'true'
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: ${{ inputs.build_context }}
@@ -166,15 +186,15 @@ runs:
         target: ${{ inputs.build_target }}
         tags: ${{ steps.meta-ghcr.outputs.tags }}
         labels: ${{ steps.meta-ghcr.outputs.labels }}
-        cache-from: type=gha,scope=${{ matrix.platform }}
-        cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+        cache-from: type=gha,scope=${{ inputs.platform }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.platform }}
         provenance: mode=max
         sbom: true
         push: true
 
     - name: Extract metadata for GAR
       id: meta-gar
-      if: inputs.google_ar == 'true' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+      if: steps.setup.outputs.publish_to_gar == 'true'
       uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
       with:
         images: ${{ inputs.google_ar_image_name }}
@@ -194,20 +214,20 @@ runs:
 
 
     - name: Setup Google Cloud authentication
-      if: inputs.google_ar == 'true' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+      if: steps.setup.outputs.publish_to_gar == 'true'
       uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
       with:
         workload_identity_provider: ${{ inputs.google_workload_identity_provider }}
         service_account: ${{ inputs.google_service_account }}
 
     - name: Configure Docker for Google Artifact Registry
-      if: inputs.google_ar == 'true' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+      if: steps.setup.outputs.publish_to_gar == 'true'
       shell: bash
       run: |
         gcloud auth configure-docker $(echo "${{ inputs.google_ar_image_name }}" | cut -d'/' -f1)
 
     - name: Build and push to GAR
-      if: inputs.google_ar == 'true' && inputs.google_ar_image_name != '' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+      if: steps.setup.outputs.publish_to_gar == 'true'
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: ${{ inputs.build_context }}
@@ -225,9 +245,7 @@ runs:
 
     - name: Build only (no push)
       id: build-only
-      if: |
-        !(inputs.ghcr == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && inputs.publish_on_pr == 'true'))) &&
-        !(inputs.google_ar == 'true' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
+      if: steps.setup.outputs.publish_to_ghcr == 'false' && steps.setup.outputs.publish_to_gar == 'false'
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: ${{ inputs.build_context }}

--- a/action.yml
+++ b/action.yml
@@ -184,6 +184,8 @@ runs:
 
     - name: Set up qemu
       uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
+      with:
+        platforms: ${{ inputs.platforms }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -247,5 +249,5 @@ runs:
         echo "ghcr_image_url=$ghcr_image_url" >> $GITHUB_OUTPUT
         echo "gar_image_url=$gar_image_url" >> $GITHUB_OUTPUT
 
-        echo "ghcr_image_url=$ghcr_image_url"
-        echo "gar_image_url=$gar_image_url"
+        echo "GHCR Image URL: $ghcr_image_url"
+        echo "GAR Image URL: $gar_image_url"

--- a/action.yml
+++ b/action.yml
@@ -182,11 +182,12 @@ runs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
 
+    - name: Set up qemu
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
-    - name: Set up qemu
-      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
 
     - name: Login to GHCR
       if: steps.setup.outputs.publish_to_ghcr == 'true'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Build and Push Container Images'
-description: 'Builds images on PRs and builds/pushes to registries on main/release branches'
+description: 'Builds images on PRs and builds/pushes to registries on default branch'
 
 inputs:
   # Image configuration
@@ -69,8 +69,8 @@ inputs:
     default: ''
 
   # Build configuration
-  architecture:
-    description: 'Architecture to build (e.g., amd64, arm64)'
+  platform:
+    description: 'platform to build (e.g., amd64, arm64)'
     required: false
     default: 'amd64'
 
@@ -101,10 +101,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    # =============================================================================
-    # BUILD IMAGES
-    # =============================================================================
-
     - name: Setup build metadata
       id: setup
       shell: bash
@@ -116,20 +112,12 @@ runs:
         fi
         echo "ghcr_image_name=$GHCR_IMAGE_NAME" >> $GITHUB_OUTPUT
 
-        # Use correct SHA for the event type
-        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
-        else
-          COMMIT_SHA="${{ github.sha }}"
-        fi
-        echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
         echo "Event: ${{ github.event_name }}"
         echo "Branch: ${{ github.ref_name }}"
-        echo "Architecture: ${{ inputs.architecture }}"
-        echo "Commit SHA: $COMMIT_SHA"
+        echo "platform: ${{ inputs.platform }}"
         if [[ "${{ inputs.google_ar }}" == "true" ]]; then
           if [[ -z "${{ inputs.google_ar_image_name }}" ]]; then
-            echo "Error: Google Artifact Registry image name is required when publshing to Google Artifact Registry is enabled"
+            echo "Error: Google Artifact Registry image name is required when publishing to Google Artifact Registry is enabled"
             exit 1
           fi
           echo "GAR Image: ${{ inputs.google_ar_image_name }}"
@@ -138,68 +126,27 @@ runs:
           echo "GHCR Image: $GHCR_IMAGE_NAME"
         fi
 
-    - name: Build images for each architecture
-      id: build-images
-      shell: bash
-      run: |
-        set -euo pipefail
-
-        ARCHITECTURE="${{ inputs.architecture }}"
-        GHCR_IMAGE_NAME="${{ steps.setup.outputs.ghcr_image_name }}"
-
-        echo "Building for architecture: $ARCHITECTURE"
-
-        # Set platform-specific runner (if needed)
-        PLATFORM="linux/$ARCHITECTURE"
-
-        # Define image tags
-        IMAGE="${GHCR_IMAGE_NAME}:${{ steps.setup.outputs.commit_sha }}"
-        CACHE_IMG="${GHCR_IMAGE_NAME}:${ARCHITECTURE}-${{ inputs.cache_suffix }}"
-
-        # Prepare build arguments
-        BUILD_ARGS=""
-        if [[ -n "${{ inputs.build_args }}" ]]; then
-          while IFS= read -r arg; do
-            if [[ -n "$arg" ]]; then
-              BUILD_ARGS="$BUILD_ARGS --build-arg $arg"
-            fi
-          done <<< "${{ inputs.build_args }}"
-        fi
-
-        # Prepare cache arguments
-        CACHE_ARGS=""
-        if [[ "${{ inputs.cache_enabled }}" == "true" ]]; then
-          if docker pull -q "$CACHE_IMG" 2>/dev/null; then
-            CACHE_ARGS="--cache-from $CACHE_IMG"
-          fi
-        fi
-
-        # Build target argument
-        TARGET_ARG=""
-        if [[ -n "${{ inputs.build_target }}" ]]; then
-          TARGET_ARG="--target ${{ inputs.build_target }}"
-        fi
-
-        # Build the image
-        docker buildx build \
-          --platform "$PLATFORM" \
-          --build-arg BUILDKIT_INLINE_CACHE=1 \
-          $BUILD_ARGS \
-          $CACHE_ARGS \
-          $TARGET_ARG \
-          --tag "$IMAGE" \
-          --tag "$CACHE_IMG" \
-          --file "${{ inputs.dockerfile_path }}" \
-          "${{ inputs.build_context }}"
-
-        # Output built image
-        echo "image=$IMAGE" >> $GITHUB_OUTPUT
-
-        echo "Built image: $IMAGE"
-
-    # =============================================================================
-    # PUBLISH TO GITHUB CONTAINER REGISTRY
-    # =============================================================================
+    - name: Extract metadata for GHCR
+      id: meta-ghcr
+      if: inputs.ghcr == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && inputs.publish_on_pr == 'true'))
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+      with:
+        images: ${{ steps.setup.outputs.ghcr_image_name }}
+        tags: |
+          # SHA for all events
+          type=sha,format=short
+          # Long SHA for all events
+          type=sha,format=long
+          # Nightly tags only for default branch pushes
+          type=raw,value=nightly,enable={{is_default_branch}}
+        labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.vendor="Sentry"
+            org.opencontainers.image.revision=${{ github.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.version=${{ github.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
 
     - name: Login to GitHub Container Registry
       if: inputs.ghcr == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && inputs.publish_on_pr == 'true'))
@@ -207,60 +154,90 @@ runs:
       run: |
         docker login ghcr.io -u "${{ github.actor }}" --password "${{ github.token }}"
 
-    - name: Push and tag image for GHCR
+    - name: Build and push to GHCR
+      id: build-and-push-to-ghcr
       if: inputs.ghcr == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && inputs.publish_on_pr == 'true'))
-      shell: bash
-      run: |
-        GHCR_IMAGE_NAME="${{ steps.setup.outputs.ghcr_image_name }}"
-        IMAGE="${{ steps.build-images.outputs.image }}"
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      with:
+        context: ${{ inputs.build_context }}
+        file: ${{ inputs.dockerfile_path }}
+        platforms: linux/${{ inputs.platform }}
+        build-args: ${{ inputs.build_args }}
+        target: ${{ inputs.build_target }}
+        tags: ${{ steps.meta-ghcr.outputs.tags }}
+        labels: ${{ steps.meta-ghcr.outputs.labels }}
+        cache-from: type=gha,scope=${{ matrix.platform }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+        provenance: mode=max
+        sbom: true
+        push: true
 
-        # Create and push SHA-tagged image
-        echo "Creating SHA-tagged image: ${GHCR_IMAGE_NAME}:${{ steps.setup.outputs.commit_sha }}"
-        docker tag "$IMAGE" "${GHCR_IMAGE_NAME}:${{ steps.setup.outputs.commit_sha }}"
-        docker push "${GHCR_IMAGE_NAME}:${{ steps.setup.outputs.commit_sha }}"
+    - name: Extract metadata for GAR
+      id: meta-gar
+      if: inputs.google_ar == 'true' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+      with:
+        images: ${{ inputs.google_ar_image_name }}
+        tags: |
+          # SHA for all events
+          type=sha,format=short
+          # Long SHA for all events
+          type=sha,format=long
+        labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.vendor="Sentry"
+            org.opencontainers.image.revision=${{ github.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.version=${{ github.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
 
-        # Create and push latest tag only on main/master branches (not PRs)
-        if [[ "${{ github.event_name }}" == "push" && ("${{ github.ref_name }}" == "main" || "${{ github.ref_name }}" == "master") ]]; then
-          echo "Creating latest tag: ${GHCR_IMAGE_NAME}:latest"
-          docker tag "$IMAGE" "${GHCR_IMAGE_NAME}:latest"
-          docker push "${GHCR_IMAGE_NAME}:latest"
-        fi
-
-    # =============================================================================
-    # PUBLISH TO GOOGLE ARTIFACT REGISTRY
-    # =============================================================================
 
     - name: Setup Google Cloud authentication
-      if: inputs.google_ar == 'true' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')
+      if: inputs.google_ar == 'true' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
       uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
       with:
         workload_identity_provider: ${{ inputs.google_workload_identity_provider }}
         service_account: ${{ inputs.google_service_account }}
 
-    - name: Setup Google Cloud SDK
-      if: inputs.google_ar == 'true' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')
-      uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
-      with:
-        version: ">= 390.0.0"
-
     - name: Configure Docker for Google Artifact Registry
-      if: inputs.google_ar == 'true' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')
+      if: inputs.google_ar == 'true' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
       shell: bash
       run: |
-        if [[ -z "${{ inputs.google_ar_image_name }}" ]]; then
-          echo "Error: Google Artifact Registry image name is required when publshing to Google Artifact Registry is enabled"
-          exit 1
-        fi
         gcloud auth configure-docker $(echo "${{ inputs.google_ar_image_name }}" | cut -d'/' -f1)
 
-    - name: Tag image for Google Artifact Registry
-      if: inputs.google_ar == 'true' && github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')
-      shell: bash
-      run: |
-        GAR_IMAGE_NAME="${{ inputs.google_ar_image_name }}"
-        IMAGE="${{ steps.build-images.outputs.image }}"
+    - name: Build and push to GAR
+      if: inputs.google_ar == 'true' && inputs.google_ar_image_name != '' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      with:
+        context: ${{ inputs.build_context }}
+        file: ${{ inputs.dockerfile_path }}
+        platforms: linux/${{ inputs.platform }}
+        build-args: ${{ inputs.build_args }}
+        target: ${{ inputs.build_target }}
+        tags: ${{ steps.meta-gar.outputs.tags }}
+        labels: ${{ steps.meta-gar.outputs.labels }}
+        cache-from: type=gha,scope=${{ inputs.platform }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.platform }}
+        provenance: mode=max
+        sbom: true
+        push: true
 
-        # Create and push SHA-tagged image
-        echo "Creating SHA-tagged image: ${GAR_IMAGE_NAME}:${{ inputs.google_ar_tag_prefix }}${{ steps.setup.outputs.commit_sha }}"
-        docker tag "$IMAGE" "${GAR_IMAGE_NAME}:${{ inputs.google_ar_tag_prefix }}${{ steps.setup.outputs.commit_sha }}"
-        docker push "${GAR_IMAGE_NAME}:${{ inputs.google_ar_tag_prefix }}${{ steps.setup.outputs.commit_sha }}"
+    - name: Build only (no push)
+      id: build-only
+      if: |
+        !(inputs.ghcr == 'true' && (github.event_name == 'push' || (github.event_name == 'pull_request' && inputs.publish_on_pr == 'true'))) &&
+        !(inputs.google_ar == 'true' && github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      with:
+        context: ${{ inputs.build_context }}
+        file: ${{ inputs.dockerfile_path }}
+        platforms: linux/${{ inputs.platform }}
+        build-args: ${{ inputs.build_args }}
+        target: ${{ inputs.build_target }}
+        tags: build-${{ inputs.image_name }}:${{ github.pull_request.head.sha || github.sha }}
+        cache-from: type=gha,scope=${{ inputs.platform }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.platform }}
+        provenance: mode=max
+        sbom: true
+        push: false

--- a/action.yml
+++ b/action.yml
@@ -74,30 +74,6 @@ inputs:
     required: false
     default: 'amd64'
 
-  # Cache configuration
-  cache_enabled:
-    description: 'Enable build cache'
-    required: false
-    default: 'true'
-
-  cache_suffix:
-    description: 'Cache image suffix'
-    required: false
-    default: 'cache'
-
-outputs:
-  image:
-    description: 'Built image tag'
-    value: ${{ steps.output-images.outputs.image }}
-
-  image_digest:
-    description: 'Image digest'
-    value: ${{ steps.output-images.outputs.digest }}
-
-  pushed:
-    description: 'Whether image was pushed to registries'
-    value: ${{ steps.output-images.outputs.pushed }}
-
 runs:
   using: 'composite'
   steps:

--- a/action.yml
+++ b/action.yml
@@ -236,8 +236,8 @@ runs:
         primary_ghcr_tag=$(echo ${{ steps.meta-ghcr.outputs.tags }} | head -n1)
         primary_gar_tag=$(echo ${{ steps.meta-gar.outputs.tags }} | head -n1)
 
-        ghcr_image_url=${{ steps.output-urls.outputs.ghcr_image_url }}:${{ primary_ghcr_tag }}
-        gar_image_url=${{ steps.output-urls.outputs.gar_image_url }}:${{ primary_gar_tag }}
+        ghcr_image_url=${{ steps.output-urls.outputs.ghcr_image_url }}:$primary_ghcr_tag
+        gar_image_url=${{ steps.output-urls.outputs.gar_image_url }}:$primary_gar_tag
 
         # Output to GitHub Actions
         echo "ghcr_image_url=$ghcr_image_url" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -189,6 +189,8 @@ runs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      with:
+        platforms: ${{ inputs.platforms }}
 
 
     - name: Login to GHCR

--- a/action.yml
+++ b/action.yml
@@ -116,11 +116,18 @@ runs:
           PUBLISH_TO_GAR="true"
         fi
 
+        # Determine if we will publish to any registry
+        WILL_PUBLISH="false"
+        if [[ "$PUBLISH_TO_GHCR" == "true" || "$PUBLISH_TO_GAR" == "true" ]]; then
+          WILL_PUBLISH="true"
+        fi
+
         echo "publish_to_ghcr=$PUBLISH_TO_GHCR" >> $GITHUB_OUTPUT
         echo "publish_to_gar=$PUBLISH_TO_GAR" >> $GITHUB_OUTPUT
+        echo "will_publish=$WILL_PUBLISH" >> $GITHUB_OUTPUT
         echo "Publishing to GHCR: $PUBLISH_TO_GHCR"
         echo "Publishing to GAR: $PUBLISH_TO_GAR"
-
+        echo "Will publish to any registry: $WILL_PUBLISH"
 
     - name: Extract metadata for GHCR
       id: meta-ghcr
@@ -130,11 +137,27 @@ runs:
         images: ${{ steps.setup.outputs.ghcr_image_name }}
         tags: |
           # SHA for all events
-          type=sha,format=short
-          # Long SHA for all events
           type=sha,format=long
           # Nightly tags only for default branch pushes
           type=raw,value=nightly,enable={{is_default_branch}}
+        labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.vendor="Sentry"
+            org.opencontainers.image.revision=${{ github.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.version=${{ github.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+
+    - name: Extract metadata for GAR
+      id: meta-gar
+      if: steps.setup.outputs.publish_to_gar == 'true'
+      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+      with:
+        images: ${{ inputs.google_ar_image_name }}
+        tags: |
+          # SHA for all events (no nightly for GAR)
+          type=sha,format=long
         labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -150,44 +173,6 @@ runs:
       run: |
         docker login ghcr.io -u "${{ github.actor }}" --password "${{ github.token }}"
 
-    - name: Build and push to GHCR
-      id: build-and-push-to-ghcr
-      if: steps.setup.outputs.publish_to_ghcr == 'true'
-      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-      with:
-        context: ${{ inputs.build_context }}
-        file: ${{ inputs.dockerfile_path }}
-        platforms: linux/${{ inputs.platform }}
-        build-args: ${{ inputs.build_args }}
-        target: ${{ inputs.build_target }}
-        tags: ${{ steps.meta-ghcr.outputs.tags }}
-        labels: ${{ steps.meta-ghcr.outputs.labels }}
-        cache-from: type=gha,scope=${{ inputs.platform }}
-        cache-to: type=gha,mode=max,scope=${{ inputs.platform }}
-        provenance: mode=max
-        sbom: true
-        push: true
-
-    - name: Extract metadata for GAR
-      id: meta-gar
-      if: steps.setup.outputs.publish_to_gar == 'true'
-      uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
-      with:
-        images: ${{ inputs.google_ar_image_name }}
-        tags: |
-          # SHA for all events
-          type=sha,format=short
-          # Long SHA for all events
-          type=sha,format=long
-        labels: |
-            org.opencontainers.image.title=${{ github.event.repository.name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.vendor="Sentry"
-            org.opencontainers.image.revision=${{ github.pull_request.head.sha || github.sha }}
-            org.opencontainers.image.version=${{ github.pull_request.head.sha || github.sha }}
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
-
 
     - name: Setup Google Cloud authentication
       if: steps.setup.outputs.publish_to_gar == 'true'
@@ -202,8 +187,8 @@ runs:
       run: |
         gcloud auth configure-docker $(echo "${{ inputs.google_ar_image_name }}" | cut -d'/' -f1)
 
-    - name: Build and push to GAR
-      if: steps.setup.outputs.publish_to_gar == 'true'
+    - name: Build and push
+      id: build-and-push
       uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: ${{ inputs.build_context }}
@@ -211,27 +196,14 @@ runs:
         platforms: linux/${{ inputs.platform }}
         build-args: ${{ inputs.build_args }}
         target: ${{ inputs.build_target }}
-        tags: ${{ steps.meta-gar.outputs.tags }}
-        labels: ${{ steps.meta-gar.outputs.labels }}
+        tags: |
+          ${{ steps.setup.outputs.publish_to_ghcr == 'true' && steps.meta-ghcr.outputs.tags || '' }}
+          ${{ steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.tags || '' }}
+          ${{ steps.setup.outputs.will_publish == 'false' && format('build-{0}:{1}', inputs.image_name, github.pull_request.head.sha || github.sha) || '' }}
+        labels: ${{ (steps.setup.outputs.publish_to_ghcr == 'true' && steps.meta-ghcr.outputs.labels) || (steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.labels) || '' }}
+        annotations: ${{ (steps.setup.outputs.publish_to_ghcr == 'true' && steps.meta-ghcr.outputs.annotations) || (steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.annotations) || '' }}
         cache-from: type=gha,scope=${{ inputs.platform }}
-        cache-to: type=gha,mode=max,scope=${{ inputs.platform }}
-        provenance: mode=max
-        sbom: true
-        push: true
-
-    - name: Build only (no push)
-      id: build-only
-      if: steps.setup.outputs.publish_to_ghcr == 'false' && steps.setup.outputs.publish_to_gar == 'false'
-      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-      with:
-        context: ${{ inputs.build_context }}
-        file: ${{ inputs.dockerfile_path }}
-        platforms: linux/${{ inputs.platform }}
-        build-args: ${{ inputs.build_args }}
-        target: ${{ inputs.build_target }}
-        tags: build-${{ inputs.image_name }}:${{ github.pull_request.head.sha || github.sha }}
-        cache-from: type=gha,scope=${{ inputs.platform }}
-        cache-to: type=gha,mode=max,scope=${{ inputs.platform }}
-        provenance: mode=max
-        sbom: true
-        push: false
+        cache-to: ${{ steps.setup.outputs.will_publish == 'true' && format('type=gha,mode=max,scope={0}', inputs.platform) || '' }}
+        provenance: ${{ steps.setup.outputs.will_publish == 'true' && 'mode=max' || 'false' }}
+        sbom: ${{ steps.setup.outputs.will_publish == 'true' }}
+        push: ${{ steps.setup.outputs.will_publish == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -162,7 +162,7 @@ runs:
         tags: |
           # SHA for all events
           # Priority for sha tags is 2000, so it will be the highest priority. https://github.com/docker/metadata-action?tab=readme-ov-file#priority-attribute
-          type=raw,value=${{ steps.setup.outputs.commit_sha }},prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }},enable={{is_default_branch}},priority=2000
+          type=raw,value=${{ steps.setup.outputs.commit_sha }},prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }},priority=2000
           # Nightly tags only for default branch pushes
           type=schedule,pattern=nightly,enable={{is_default_branch}}
         labels: |
@@ -182,7 +182,7 @@ runs:
         images: ${{ inputs.google_ar_image_name }}
         tags: |
           # SHA for all events (no nightly for GAR)
-          type=raw,value=${{ steps.setup.outputs.commit_sha }},prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }},enable={{is_default_branch}},priority=2000
+          type=raw,value=${{ steps.setup.outputs.commit_sha }},prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }},priority=2000
         labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}

--- a/action.yml
+++ b/action.yml
@@ -144,6 +144,15 @@ runs:
         echo "Publishing to GAR: $PUBLISH_TO_GAR"
         echo "Will publish to any registry: $WILL_PUBLISH"
 
+        # Determine the correct commit SHA based on event type
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
+        else
+          COMMIT_SHA="${{ github.sha }}"
+        fi
+        echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+        echo "Using commit SHA: $COMMIT_SHA"
+
     - name: Extract metadata for GHCR
       id: meta-ghcr
       if: steps.setup.outputs.publish_to_ghcr == 'true'
@@ -152,15 +161,15 @@ runs:
         images: ${{ steps.setup.outputs.ghcr_image_name }}
         tags: |
           # SHA for all events
-          type=sha,format=long,prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }}
+          type=sha,value=${{ steps.setup.outputs.commit_sha }},format=long,prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }}
           # Nightly tags only for default branch pushes
           type=raw,value=nightly,enable={{is_default_branch}}
         labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.vendor="Sentry"
-            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha || github.sha }}
-            org.opencontainers.image.version=${{ github.event.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.revision=${{ steps.setup.outputs.commit_sha }}
+            org.opencontainers.image.version=${{ steps.setup.outputs.commit_sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
 
@@ -172,13 +181,13 @@ runs:
         images: ${{ inputs.google_ar_image_name }}
         tags: |
           # SHA for all events (no nightly for GAR)
-          type=sha,format=long,prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }}
+          type=sha,value=${{ steps.setup.outputs.commit_sha }},format=long,prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }}
         labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.vendor="Sentry"
-            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha || github.sha }}
-            org.opencontainers.image.version=${{ github.event.pull_request.head.sha || github.sha }}
+            org.opencontainers.image.revision=${{ steps.setup.outputs.commit_sha }}
+            org.opencontainers.image.version=${{ steps.setup.outputs.commit_sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
 

--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ runs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ github.token }}
 
 
     - name: Setup Google Cloud authentication

--- a/action.yml
+++ b/action.yml
@@ -229,8 +229,8 @@ runs:
           ${{ steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.tags || '' }}
         labels: ${{ (steps.setup.outputs.publish_to_ghcr == 'true' && steps.meta-ghcr.outputs.labels) || (steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.labels) || '' }}
         annotations: ${{ (steps.setup.outputs.publish_to_ghcr == 'true' && steps.meta-ghcr.outputs.annotations) || (steps.setup.outputs.publish_to_gar == 'true' && steps.meta-gar.outputs.annotations) || '' }}
-        cache-from: type=gha,scope=${{ inputs.platforms }}
-        cache-to: ${{ steps.setup.outputs.will_publish == 'true' && format('type=gha,mode=max,scope={0}', inputs.platforms) || '' }}
+        cache-from: type=gha,scope=buildcache
+        cache-to: ${{ steps.setup.outputs.will_publish == 'true' && 'type=gha,mode=max,scope=buildcache' || '' }}
         provenance: ${{ steps.setup.outputs.will_publish == 'true' && 'mode=max' || 'false' }}
         sbom: ${{ steps.setup.outputs.will_publish == 'true' }}
         push: ${{ steps.setup.outputs.will_publish == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -161,9 +161,10 @@ runs:
         images: ${{ steps.setup.outputs.ghcr_image_name }}
         tags: |
           # SHA for all events
-          type=sha,value=${{ steps.setup.outputs.commit_sha }},format=long,prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }}
+          # Priority for sha tags is 2000, so it will be the highest priority. https://github.com/docker/metadata-action?tab=readme-ov-file#priority-attribute
+          type=raw,value=${{ steps.setup.outputs.commit_sha }},prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }},enable={{is_default_branch}},priority=2000
           # Nightly tags only for default branch pushes
-          type=raw,value=nightly,enable={{is_default_branch}}
+          type=schedule,pattern=nightly,enable={{is_default_branch}}
         labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}
@@ -181,7 +182,7 @@ runs:
         images: ${{ inputs.google_ar_image_name }}
         tags: |
           # SHA for all events (no nightly for GAR)
-          type=sha,value=${{ steps.setup.outputs.commit_sha }},format=long,prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }}
+          type=raw,value=${{ steps.setup.outputs.commit_sha }},prefix=${{ inputs.tag_prefix }},suffix=${{ inputs.tag_suffix }},enable={{is_default_branch}},priority=2000
         labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
             org.opencontainers.image.description=${{ github.event.repository.description }}

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,16 @@ inputs:
     required: false
     default: 'amd64'
 
+
+outputs:
+  ghcr_image_url:
+    description: 'Full GHCR image URL with primary tag (e.g., ghcr.io/owner/repo:sha-abc123)'
+    value: ${{ steps.output-urls.outputs.ghcr_image_url }}
+
+  gar_image_url:
+    description: 'Full GAR image URL with primary tag'
+    value: ${{ steps.output-urls.outputs.gar_image_url }}
+
 runs:
   using: 'composite'
   steps:
@@ -216,3 +226,22 @@ runs:
         provenance: ${{ steps.setup.outputs.will_publish == 'true' && 'mode=max' || 'false' }}
         sbom: ${{ steps.setup.outputs.will_publish == 'true' }}
         push: ${{ steps.setup.outputs.will_publish == 'true' }}
+
+    - name: Output image URLs
+      id: output-urls
+      shell: bash
+      run: |
+        set -e
+
+        primary_ghcr_tag=$(echo ${{ steps.meta-ghcr.outputs.tags }} | head -n1)
+        primary_gar_tag=$(echo ${{ steps.meta-gar.outputs.tags }} | head -n1)
+
+        ghcr_image_url=${{ steps.output-urls.outputs.ghcr_image_url }}:${{ primary_ghcr_tag }}
+        gar_image_url=${{ steps.output-urls.outputs.gar_image_url }}:${{ primary_gar_tag }}
+
+        # Output to GitHub Actions
+        echo "ghcr_image_url=$ghcr_image_url" >> $GITHUB_OUTPUT
+        echo "gar_image_url=$gar_image_url" >> $GITHUB_OUTPUT
+
+        echo "ghcr_image_url=$ghcr_image_url"
+        echo "gar_image_url=$gar_image_url"


### PR DESCRIPTION
This PR introduces a new composite GitHub Action that streamlines container image building and publishing workflows. It publishes to both GHCR and Google Artifact Registry. 

GHCR for CI and dev workflows
GAR for production

See README for more details on the inputs and general functionality

