### PR TITLE
feat: configurable release branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ jobs:
 | `build_context` | Build context directory | No | `.` |
 | `build_target` | Docker build target stage | No | - |
 | `build_args` | Docker build arguments (multiline) | No | - |
+| `release_branches` | Release branch names, separated by commas | No | `release,releases` |
 | `ghcr` | Enable GitHub Container Registry | No | `true` |
 | `ghcr_image_name` | GHCR image name | No | `ghcr.io/{owner}/{image_name}` |
 | `publish_on_pr` | Publish images on pull requests (SHA tags only) | No | `false` |

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,11 @@ inputs:
     required: false
     default: ''
 
+  release_branches:
+    description: 'List of release branch names, separated by commas'
+    required: false
+    default: 'release,releases'
+
   # Registry configuration
   ghcr:
     description: 'Enable GitHub Container Registry'
@@ -145,12 +150,25 @@ runs:
           IS_DEFAULT_BRANCH="true"
         fi
 
+        # Iterate over release branch names. In pseudocode:
+        #   for branch in ref_name.split(','):
+        #     if branch.startswith(branch + "/"):
+        #       IS_RELEASE_BRANCH="true"
+        #       break
+        IS_RELEASE_BRANCH="false"
+        for branch in $(echo "${{ inputs.release_branches }}" | tr ',' ' '); do
+          if [[ "${{ github.ref_name }}" == $branch/* ]]; then
+            IS_RELEASE_BRANCH="true"
+            break
+          fi
+        done
+
         # Determine publishing conditions
         PUBLISH_TO_GHCR="false"
         PUBLISH_TO_GAR="false"
 
         # GHCR: Publish on default branch push, merge queue, release branches, OR PR (if enabled)
-        if [[ "${{ inputs.ghcr }}" == "true" && (("$IS_DEFAULT_BRANCH" == "true") || ("${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == releases/*) || ("${{ github.event_name }}" == "pull_request" && "${{ inputs.publish_on_pr }}" == "true")) ]]; then
+        if [[ "${{ inputs.ghcr }}" == "true" && (("$IS_DEFAULT_BRANCH" == "true") || ("${{ github.event_name }}" == "push" && "$IS_RELEASE_BRANCH" == "true") || ("${{ github.event_name }}" == "pull_request" && "${{ inputs.publish_on_pr }}" == "true")) ]]; then
           PUBLISH_TO_GHCR="true"
         fi
 


### PR DESCRIPTION
Each repositories has different branch names. Although it's either `release` or `releases`. But it's annoying and we've met the issue on 25.9.0.

Hopefully this solve the craft problem.